### PR TITLE
fix: suppress Monaco chunk size warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -59,8 +59,10 @@ export default defineConfig({
 				warn(warning);
 			}
 		},
-		// Increase chunk size warning limit to 1MB for Monaco Editor
-		chunkSizeWarningLimit: 1000,
+		// Monaco Editor chunk is ~3.8MB unminified (958KB gzipped)
+		// It's lazy-loaded only when VSCodeDemo renders, so large size is acceptable
+		// Set threshold to 4MB to suppress warning while catching other issues
+		chunkSizeWarningLimit: 4000,
 		// Use Terser for better compression in production
 		minify: 'terser',
 		terserOptions: {


### PR DESCRIPTION
## Summary
- Suppress expected Monaco Editor chunk size warning (3.8MB unminified, 958KB gzipped)
- Monaco is lazy-loaded via dynamic import, only when VSCodeDemo renders
- Raise `chunkSizeWarningLimit` from 1MB to 4MB to suppress noise
- Add comments documenting rationale

## Related Changes
- Previous commit fixed circular chunk warning (components ↔ routes)
- Both warnings now resolved, clean production build

## Testing
- ✅ `pnpm build:prod` completes without warnings
- ✅ Monaco still chunked separately and lazy-loaded
- ✅ Build output clean and optimized