### PR TITLE
feat: add visual breadcrumbs to doc pages

### DIFF
--- a/src/lib/components/Breadcrumbs.svelte
+++ b/src/lib/components/Breadcrumbs.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	export let items: Array<{ label: string; href?: string; current?: boolean }> = [];
+</script>
+
+<nav aria-label="Breadcrumb" class="mb-4 sm:mb-6">
+	<ol class="flex items-center space-x-2 text-sm text-gray-600 overflow-x-auto whitespace-nowrap">
+		{#each items as item, index}
+			<li class="flex items-center">
+				{#if index > 0}
+					<svg class="w-4 h-4 mx-2 text-gray-400" fill="currentColor" viewBox="0 0 20 20">
+						<path
+							fill-rule="evenodd"
+							d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+							clip-rule="evenodd"
+						/>
+					</svg>
+				{/if}
+
+				{#if item.current}
+					<span class="font-medium text-gray-900" aria-current="page">
+						{item.label}
+					</span>
+				{:else}
+					<a href={item.href} class="hover:text-brand-blue transition-colors">
+						{item.label}
+					</a>
+				{/if}
+			</li>
+		{/each}
+	</ol>
+</nav>

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -1,82 +1,92 @@
 <script lang="ts">
-  import DocsSidebar from '$lib/components/DocsSidebar.svelte';
-  import CanonicalLink from '$lib/components/CanonicalLink.svelte';
-  import BreadcrumbSchema from '$lib/components/BreadcrumbSchema.svelte';
-  import SocialMeta from '$lib/components/SocialMeta.svelte';
-  import '../../app.css';
-  import { page } from '$app/stores';
-  
-  let isSidebarOpen = false;
-  
-  function closeSidebar() {
-    isSidebarOpen = false;
-  }
-  
-  $: breadcrumbs = getBreadcrumbs($page.url.pathname);
-  
-  function getBreadcrumbs(path: string) {
-    const parts = path.split('/').filter(Boolean);
-    const breadcrumbs = [{ name: 'Home', url: '/' }];
-    
-    let currentPath = '';
-    for (const part of parts) {
-      currentPath += `/${part}`;
-      
-      // Format the name from the URL part
-      let name = part.charAt(0).toUpperCase() + part.slice(1);
-      name = name.replace(/-/g, ' ');
-      
-      breadcrumbs.push({ name, url: currentPath });
-    }
-    
-    return breadcrumbs;
-  }
+	import DocsSidebar from '$lib/components/DocsSidebar.svelte';
+	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
+	import CanonicalLink from '$lib/components/CanonicalLink.svelte';
+	import BreadcrumbSchema from '$lib/components/BreadcrumbSchema.svelte';
+	import SocialMeta from '$lib/components/SocialMeta.svelte';
+	import '../../app.css';
+	import { page } from '$app/stores';
+
+	let isSidebarOpen = false;
+
+	function closeSidebar() {
+		isSidebarOpen = false;
+	}
+
+	$: breadcrumbs = getBreadcrumbs($page.url.pathname);
+	$: breadcrumbItems = breadcrumbs.map((b, i) => ({
+		label: b.name,
+		href: i < breadcrumbs.length - 1 ? b.url : undefined,
+		current: i === breadcrumbs.length - 1
+	}));
+
+	function getBreadcrumbs(path: string) {
+		const parts = path.split('/').filter(Boolean);
+		const breadcrumbs = [{ name: 'Home', url: '/' }];
+
+		let currentPath = '';
+		for (const part of parts) {
+			currentPath += `/${part}`;
+
+			// Format the name from the URL part
+			let name = part.charAt(0).toUpperCase() + part.slice(1);
+			name = name.replace(/-/g, ' ');
+
+			breadcrumbs.push({ name, url: currentPath });
+		}
+
+		return breadcrumbs;
+	}
 </script>
 
 <svelte:head>
-  <title>Structured Text Documentation - ControlForge Systems</title>
-  <meta name="description" content="Complete documentation for IEC 61131-3 Structured Text programming language. Learn syntax, variables, control structures, and best practices." />
-  <CanonicalLink path={$page.url.pathname} />
-  <BreadcrumbSchema breadcrumbs={breadcrumbs} />
-  <SocialMeta 
-    title="Structured Text Documentation - ControlForge Systems"
-    description="Complete guide to IEC 61131-3 Structured Text for industrial automation. Master PLC programming with our comprehensive documentation."
-    url={$page.url.pathname}
-  />
+	<title>Structured Text Documentation - ControlForge Systems</title>
+	<meta
+		name="description"
+		content="Complete documentation for IEC 61131-3 Structured Text programming language. Learn syntax, variables, control structures, and best practices."
+	/>
+	<CanonicalLink path={$page.url.pathname} />
+	<BreadcrumbSchema {breadcrumbs} />
+	<SocialMeta
+		title="Structured Text Documentation - ControlForge Systems"
+		description="Complete guide to IEC 61131-3 Structured Text for industrial automation. Master PLC programming with our comprehensive documentation."
+		url={$page.url.pathname}
+	/>
 </svelte:head>
 
 <div class="flex min-h-screen">
-  <!-- Mobile overlay -->
-  {#if isSidebarOpen}
-    <div 
-      class="md:hidden fixed inset-0 bg-black bg-opacity-50 z-40" 
-      on:click={closeSidebar}
-      on:keydown={(e) => e.key === 'Escape' && closeSidebar()}
-      role="button"
-      tabindex="0"
-    ></div>
-  {/if}
+	<!-- Mobile overlay -->
+	{#if isSidebarOpen}
+		<div
+			class="md:hidden fixed inset-0 bg-black bg-opacity-50 z-40"
+			on:click={closeSidebar}
+			on:keydown={(e) => e.key === 'Escape' && closeSidebar()}
+			role="button"
+			tabindex="0"
+		></div>
+	{/if}
 
-  <!-- Sidebar - Hidden by default on mobile, always visible on desktop -->
-  <div 
-    class="fixed md:relative top-0 left-0 h-full z-50 transform transition-transform duration-300 ease-in-out {
-      isSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
-    }"
-  >
-    <DocsSidebar on:navigate={closeSidebar} />
-  </div>
-  
-  <!-- Main content with proper margins -->
-  <main class="flex-1 p-4 md:p-8 max-w-4xl md:ml-0 {isSidebarOpen ? 'md:ml-64' : ''}">
-    <slot />
-  </main>
+	<!-- Sidebar - Hidden by default on mobile, always visible on desktop -->
+	<div
+		class="fixed md:relative top-0 left-0 h-full z-50 transform transition-transform duration-300 ease-in-out {isSidebarOpen
+			? 'translate-x-0'
+			: '-translate-x-full md:translate-x-0'}"
+	>
+		<DocsSidebar on:navigate={closeSidebar} />
+	</div>
+
+	<!-- Main content with proper margins -->
+	<main class="flex-1 p-4 md:p-8 max-w-4xl md:ml-0 {isSidebarOpen ? 'md:ml-64' : ''}">
+		<Breadcrumbs items={breadcrumbItems} />
+		<slot />
+	</main>
 </div>
 
 <style>
-  /* Ensure responsive behavior */
-  @media (max-width: 768px) {
-    :global(body) {
-      overflow-x: hidden;
-    }
-  }
+	/* Ensure responsive behavior */
+	@media (max-width: 768px) {
+		:global(body) {
+			overflow-x: hidden;
+		}
+	}
 </style>


### PR DESCRIPTION
## Summary
- New Breadcrumbs.svelte component
- Renders: Home > Documentation > Current Page
- Chevron separators
- Mobile responsive (horizontal scroll)
- ARIA accessible (aria-current on current page)
- Integrated into all doc pages via docs/+layout.svelte

Closes #12