### PR TITLE
Update dependencies (Phase 1: Svelte 4-compatible)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
 		"@sveltejs/adapter-auto": "^3.1.1",
-		"@sveltejs/kit": "^2.5.4",
+		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^3.0.2",
 		"@typescript-eslint/eslint-plugin": "^8.55.0",
 		"@typescript-eslint/parser": "^8.55.0",
@@ -48,8 +48,8 @@
 		"tslib": "^2.6.2",
 		"typescript": "^5.4.2",
 		"vite": "^5.1.6",
-		"vite-bundle-analyzer": "^0.22.3",
-		"vite-plugin-devtools-json": "^0.2.0"
+		"vite-bundle-analyzer": "^1.3.6",
+		"vite-plugin-devtools-json": "^1.0.0"
 	},
 	"type": "module",
 	"dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         specifier: ^3.1.1
         version: 3.3.1(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(terser@5.46.0)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(terser@5.46.0)))
       '@sveltejs/kit':
-        specifier: ^2.5.4
+        specifier: ^2.50.2
         version: 2.50.2(@sveltejs/vite-plugin-svelte@3.1.2(svelte@4.2.20)(vite@5.4.21(terser@5.46.0)))(svelte@4.2.20)(typescript@5.9.3)(vite@5.4.21(terser@5.46.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.2
@@ -85,11 +85,11 @@ importers:
         specifier: ^5.1.6
         version: 5.4.21(terser@5.46.0)
       vite-bundle-analyzer:
-        specifier: ^0.22.3
-        version: 0.22.3
+        specifier: ^1.3.6
+        version: 1.3.6
       vite-plugin-devtools-json:
-        specifier: ^0.2.0
-        version: 0.2.1(vite@5.4.21(terser@5.46.0))
+        specifier: ^1.0.0
+        version: 1.0.0(vite@5.4.21(terser@5.46.0))
 
 packages:
 
@@ -1656,14 +1656,14 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-bundle-analyzer@0.22.3:
-    resolution: {integrity: sha512-Ce8V+IZbACAHkEIG2GVu7fwKwtKtwfqSJKXQedYWHOadf9CY8s0MGddJIWu++8ZvuC8NJPH74geDsAS6HJvsRw==}
+  vite-bundle-analyzer@1.3.6:
+    resolution: {integrity: sha512-elFXkF9oGy4CJEeOdP1DSEHRDKWfmaEDfT9/GuF4jmyfmUF6nC//iN+ythqMEVvrtchOEHGKLumZwnu1NjoI0w==}
     hasBin: true
 
-  vite-plugin-devtools-json@0.2.1:
-    resolution: {integrity: sha512-5aiNvf/iLTuLR1dUqoI5CLLGgeK2hd6u+tA+RIp7GUZDyAcM6ECaUEWOOtGpidbcxbkKq++KtmSqA3jhMbPwMA==}
+  vite-plugin-devtools-json@1.0.0:
+    resolution: {integrity: sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw==}
     peerDependencies:
-      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -3241,9 +3241,9 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-bundle-analyzer@0.22.3: {}
+  vite-bundle-analyzer@1.3.6: {}
 
-  vite-plugin-devtools-json@0.2.1(vite@5.4.21(terser@5.46.0)):
+  vite-plugin-devtools-json@1.0.0(vite@5.4.21(terser@5.46.0)):
     dependencies:
       uuid: 11.1.0
       vite: 5.4.21(terser@5.46.0)


### PR DESCRIPTION
## Summary
- vite-bundle-analyzer: 0.22.3 → 1.3.6
- vite-plugin-devtools-json: 0.2.1 → 1.0.0
- @sveltejs/kit: 2.5.4 → 2.50.2 (latest Svelte 4-compatible)

## Testing
- `pnpm check` passed (1 warning - unused prop)
- `pnpm build:prod` succeeded

## Notes
Deferred: Svelte 5, Tailwind 4, Vite 7 (breaking changes require separate migration)