### PR TITLE
Auto-generate sitemap from git history

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"prod:build": "pnpm prebuild && pnpm build:prod",
 		"prod:deploy:copy": "rsync -avz -e 'ssh' ./* homelab:~/ssd-2tb/apps/michael/controlforge-website --include-from='prod.deploy.files.txt' --exclude '*'",
 		"prod:deploy:run": "ssh homelab 'cd ~/ssd-2tb/apps/michael/controlforge-website && docker compose -f prod.compose.yml up -d && docker restart controlforge-website'",
-		"prebuild": "node scripts/generate-build-info.cjs",
+		"prebuild": "node scripts/generate-build-info.cjs && node scripts/generate-sitemap.cjs",
 		"postinstall": "node scripts/generate-build-info.cjs"
 	},
 	"devDependencies": {
@@ -28,6 +28,7 @@
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/kit": "^2.51.0",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"@types/node": "^25.2.3",
 		"@typescript-eslint/eslint-plugin": "^8.55.0",
 		"@typescript-eslint/parser": "^8.55.0",
 		"autoprefixer": "^10.4.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,20 +10,23 @@ importers:
     dependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.1
-        version: 3.0.10(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))
+        version: 3.0.10(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.0(jiti@1.21.7))
       '@sveltejs/adapter-auto':
         specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))
+        version: 7.0.1(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))
       '@sveltejs/kit':
         specifier: ^2.51.0
-        version: 2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+        version: 2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+        version: 6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.55.0
         version: 8.55.0(@typescript-eslint/parser@8.55.0(eslint@10.0.0(jiti@1.21.7))(typescript@5.9.3))(eslint@10.0.0(jiti@1.21.7))(typescript@5.9.3)
@@ -83,13 +86,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(jiti@1.21.7)(terser@5.46.0)
+        version: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)
       vite-bundle-analyzer:
         specifier: ^1.3.6
         version: 1.3.6
       vite-plugin-devtools-json:
         specifier: ^1.0.0
-        version: 1.0.0(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+        version: 1.0.0(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
 
 packages:
 
@@ -571,6 +574,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/node@25.2.3':
+    resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1523,6 +1529,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -1937,19 +1946,19 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))':
     dependencies:
-      '@sveltejs/kit': 2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+      '@sveltejs/kit': 2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))':
     dependencies:
-      '@sveltejs/kit': 2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+      '@sveltejs/kit': 2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
 
-  '@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))':
+  '@sveltejs/kit@2.51.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -1962,26 +1971,26 @@ snapshots:
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
       svelte: 5.51.0
-      vite: 7.3.1(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
       obug: 2.1.1
       svelte: 5.51.0
-      vite: 7.3.1(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)))(svelte@5.51.0)(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.51.0
-      vite: 7.3.1(jiti@1.21.7)(terser@5.46.0)
-      vitefu: 1.1.1(vite@7.3.1(jiti@1.21.7)(terser@5.46.0))
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0))
 
   '@types/cookie@0.6.0': {}
 
@@ -1998,6 +2007,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/node@25.2.3':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/trusted-types@2.0.7': {}
 
@@ -3003,6 +3016,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.16.0: {}
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -3052,12 +3067,12 @@ snapshots:
 
   vite-bundle-analyzer@1.3.6: {}
 
-  vite-plugin-devtools-json@1.0.0(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)):
+  vite-plugin-devtools-json@1.0.0(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)):
     dependencies:
       uuid: 11.1.0
-      vite: 7.3.1(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)
 
-  vite@7.3.1(jiti@1.21.7)(terser@5.46.0):
+  vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3066,13 +3081,14 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.2.3
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.46.0
 
-  vitefu@1.1.1(vite@7.3.1(jiti@1.21.7)(terser@5.46.0)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)):
     optionalDependencies:
-      vite: 7.3.1(jiti@1.21.7)(terser@5.46.0)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@1.21.7)(terser@5.46.0)
 
   which@2.0.2:
     dependencies:

--- a/scripts/generate-sitemap.cjs
+++ b/scripts/generate-sitemap.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const BASE_URL = 'https://controlforge.dev';
+
+const routes = [
+	{ url: '', priority: 1.0, changefreq: 'weekly' },
+	{ url: 'docs', priority: 0.9, changefreq: 'weekly' },
+	{ url: 'docs/syntax', priority: 0.8, changefreq: 'weekly' },
+	{ url: 'docs/variables', priority: 0.8, changefreq: 'weekly' },
+	{ url: 'docs/data-types', priority: 0.8, changefreq: 'weekly' },
+	{ url: 'docs/functions', priority: 0.8, changefreq: 'weekly' },
+	{ url: 'docs/standard-functions', priority: 0.7, changefreq: 'weekly' },
+	{ url: 'docs/standard-function-blocks', priority: 0.7, changefreq: 'weekly' },
+	{ url: 'docs/control', priority: 0.8, changefreq: 'weekly' },
+	{ url: 'docs/advanced-constructs', priority: 0.7, changefreq: 'weekly' },
+	{ url: 'docs/examples', priority: 0.8, changefreq: 'weekly' },
+	{ url: 'docs/best-practices', priority: 0.7, changefreq: 'weekly' }
+];
+
+/**
+ * Get last modified date from git history for a file path
+ */
+function getLastModified(routePath) {
+	try {
+		const filePath = routePath ? `src/routes/${routePath}/+page.svelte` : 'src/routes/+page.svelte';
+
+		const timestamp = execSync(`git log -1 --format=%cI "${filePath}"`, {
+			encoding: 'utf-8'
+		}).trim();
+
+		return timestamp || new Date().toISOString();
+	} catch {
+		return new Date().toISOString();
+	}
+}
+
+function generateSitemap() {
+	const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${routes
+	.map(
+		(route) => `  <url>
+    <loc>${BASE_URL}/${route.url}</loc>
+    <lastmod>${getLastModified(route.url)}</lastmod>
+    <changefreq>${route.changefreq}</changefreq>
+    <priority>${route.priority}</priority>
+  </url>`
+	)
+	.join('\n')}
+</urlset>
+`;
+
+	const outputPath = path.join(process.cwd(), 'static', 'sitemap.xml');
+	fs.writeFileSync(outputPath, sitemap, 'utf-8');
+	console.log(`✓ Generated sitemap.xml with ${routes.length} routes`);
+}
+
+generateSitemap();

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -2,73 +2,73 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://controlforge.dev/</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2026-02-14T13:54:29+08:00</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
+    <priority>1</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/syntax</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/variables</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/data-types</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/functions</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/standard-functions</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/standard-function-blocks</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/control</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/advanced-constructs</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/examples</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://controlforge.dev/docs/best-practices</loc>
-    <lastmod>2025-06-16</lastmod>
+    <lastmod>2025-06-23T10:28:46+08:00</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
## Summary
- Build script generates sitemap.xml from routes
- Uses git log for accurate lastmod timestamps
- Runs automatically in prebuild hook

## Changes
- scripts/generate-sitemap.cjs: Extracts routes + git commit dates
- package.json: Added sitemap generation to prebuild
- static/sitemap.xml: Now auto-generated (no manual updates)

## Testing
- Build succeeds
- Sitemap accessible at /sitemap.xml
- lastmod dates match git history

Closes #16